### PR TITLE
Follow SCL SIG precedence

### DIFF
--- a/CentOS-OpenStack.repo
+++ b/CentOS-OpenStack.repo
@@ -5,14 +5,14 @@
 
 [centos-openstack-OPENSTACK_VERSION]
 name=CentOS-$releasever - OpenStack OPENSTACK_VERSION
-baseurl=http://mirror.centos.org/centos/$releasever/cloud/openstack-OPENSTACK_VERSION/$basearch/
+baseurl=http://mirror.centos.org/centos/$releasever/cloud/$basearch/openstack-OPENSTACK_VERSION/
 gpgcheck=1
 enabled=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Cloud
 
 [centos-openstack-OPENSTACK_VERSION-test]
 name=CentOS-$releasever - OpenStack OPENSTACK_VERSION Testing
-baseurl=http://buildlogs.centos.org/centos/$releasever/cloud/openstack-OPENSTACK_VERSION/$basearch/
+baseurl=http://buildlogs.centos.org/centos/$releasever/cloud/$basearch/openstack-OPENSTACK_VERSION/
 gpgcheck=1
 enabled=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Cloud


### PR DESCRIPTION
arch is next to SIG name in repourl e.g. /centos/6/SCL/x86_64/python27/
